### PR TITLE
Set XamarinBuildDownloadDir in a Directory.Build.props file.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+	<PropertyGroup>
+		<XamarinBuildDownloadDir>$(HOME)\Library\Caches\XamarinBuildDownload\</XamarinBuildDownloadDir>
+	</PropertyGroup>
+</Project>


### PR DESCRIPTION
This fixes the build.